### PR TITLE
Removed 'clear;' before ShTerminalRunner to prevent errors when using…

### DIFF
--- a/src/main/kotlin/org/jetbrains/mcpserverplugin/terminal/Terminal.kt
+++ b/src/main/kotlin/org/jetbrains/mcpserverplugin/terminal/Terminal.kt
@@ -103,7 +103,7 @@ class ExecuteTerminalCommandTool : AbstractMcpTool<ExecuteTerminalCommandArgs>()
             }
 
             val terminalWidget =
-                ShTerminalRunner.run(project, "clear; " + args.command, project.basePath ?: "", "MCP Command", true)
+                ShTerminalRunner.run(project, args.command, project.basePath ?: "", "MCP Command", true)
             val shellWidget =
                 if (terminalWidget != null) ShellTerminalWidget.asShellJediTermWidget(terminalWidget) else null
 


### PR DESCRIPTION
Removed 'clear;' before ShTerminalRunner to prevent errors when using cmd and avoid clearing the terminal screen unnecessarily.